### PR TITLE
pmemcheck: add register pmem file macro

### DIFF
--- a/pmemcheck/pmemcheck.h
+++ b/pmemcheck/pmemcheck.h
@@ -51,6 +51,7 @@
 typedef
    enum {
        VG_USERREQ__PMC_REGISTER_PMEM_MAPPING = VG_USERREQ_TOOL_BASE('P','C'),
+       VG_USERREQ__PMC_REGISTER_PMEM_FILE,
        VG_USERREQ__PMC_REMOVE_PMEM_MAPPING,
        VG_USERREQ__PMC_CHECK_IS_PMEM_MAPPING,
        VG_USERREQ__PMC_PRINT_PMEM_MAPPINGS,
@@ -77,6 +78,14 @@ typedef
     VALGRIND_DO_CLIENT_REQUEST_EXPR(0 /* default return */,                 \
                             VG_USERREQ__PMC_REGISTER_PMEM_MAPPING,          \
                             (_qzz_addr), (_qzz_len), 0, 0, 0)
+
+/** Register a persistent memory file */
+#define VALGRIND_PMC_REGISTER_PMEM_FILE(_qzz_desc, _qzz_addr_base,          \
+                                        _qzz_size, _qzz_offset)             \
+    VALGRIND_DO_CLIENT_REQUEST_EXPR(0 /* default return */,                 \
+                            VG_USERREQ__PMC_REGISTER_PMEM_FILE,             \
+                            (_qzz_desc), (_qzz_addr_base), (_qzz_size),     \
+                            (_qzz_offset), 0)
 
 /** Remove a persistent memory mapping region */
 #define VALGRIND_PMC_REMOVE_PMEM_MAPPING(_qzz_addr,_qzz_len)         \

--- a/pmemcheck/tests/Makefile.am
+++ b/pmemcheck/tests/Makefile.am
@@ -33,7 +33,6 @@ EXTRA_DIST = \
 	cas.stderr.exp cas.stdout.exp cas.vgtest \
 	flush_check.stderr.exp flush_check.stdout.exp flush_check.vgtest
 
-
 check_PROGRAMS = \
 	const_store \
 	tmp_store \

--- a/pmemcheck/tests/logging_related/Makefile.am
+++ b/pmemcheck/tests/logging_related/Makefile.am
@@ -19,8 +19,10 @@ dist_noinst_SCRIPTS = \
 	filter_stderr
 
 EXTRA_DIST = \
-	logging.stderr.exp logging.stdout.exp logging.vgtest
+	logging.stderr.exp logging.stdout.exp logging.vgtest \
+	register_file.stderr.exp register_file.stdout.exp register_file.vgtest
 
 check_PROGRAMS = \
-	logging
+	logging \
+	register_file
 

--- a/pmemcheck/tests/logging_related/register_file.stderr.exp
+++ b/pmemcheck/tests/logging_related/register_file.stderr.exp
@@ -1,0 +1,1 @@
+START|REGISTER_FILE;/tmp/pmemcheck.testfile;0x64;0x800;0x0|STOP

--- a/pmemcheck/tests/logging_related/register_file.vgtest
+++ b/pmemcheck/tests/logging_related/register_file.vgtest
@@ -1,0 +1,2 @@
+prog: register_file
+vgopts: -q --log-stores=yes --print-summary=no


### PR DESCRIPTION
The add file macro enables binding the mapped persistent memory regions to specific files. This is especially useful for post-processing log files.
