### PR TITLE
pmemcheck: fix improper removal of aligned regions

### DIFF
--- a/pmemcheck/pmc_main.c
+++ b/pmemcheck/pmc_main.c
@@ -239,11 +239,14 @@ remove_region(struct pmem_st *region, OSet *region_set)
             new_region->addr = region_max_addr;
             new_region->size = mod_entry_max_addr - new_region->addr;
             VG_(OSetGen_Insert)(region_set, new_region);
-        } else if (modified_entry->addr > region->addr) {
+        } else if ((modified_entry->addr >= region->addr) &&
+                (mod_entry_max_addr > region_max_addr)) {
             /* head overlaps */
+            modified_entry->size -= region_max_addr - modified_entry->addr;
             modified_entry->addr = region_max_addr;
             VG_(OSetGen_Insert)(region_set, modified_entry);
-        } else if (mod_entry_max_addr < region_max_addr) {
+        } else if ((mod_entry_max_addr <= region_max_addr) &&
+                (region->addr > modified_entry->addr)) {
             /* tail overlaps */
             modified_entry->size = region->addr - modified_entry->addr;
             VG_(OSetGen_Insert)(region_set, modified_entry);

--- a/pmemcheck/tests/address_specific/Makefile.am
+++ b/pmemcheck/tests/address_specific/Makefile.am
@@ -22,8 +22,10 @@ EXTRA_DIST = \
 	region_manipulation.stderr.exp region_manipulation.stdout.exp \
 		region_manipulation.vgtest \
 	remove_regions.stderr.exp remove_regions.stdout.exp \
-		remove_regions.vgtest
-
+		remove_regions.vgtest \
+	remove_aligned_region.stderr.exp remove_aligned_region.stdout.exp \
+		remove_aligned_region.vgtest
 check_PROGRAMS = \
 	region_manipulation \
-	remove_regions
+	remove_regions \
+	remove_aligned_region

--- a/pmemcheck/tests/address_specific/remove_aligned_region.c
+++ b/pmemcheck/tests/address_specific/remove_aligned_region.c
@@ -1,0 +1,32 @@
+/*
+ * Persistent memory checker.
+ * Copyright (c) 2015, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, or (at your option) any later version, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#include "../../pmemcheck.h"
+
+
+int main ( void )
+{
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x100, 0x40);
+    VALGRIND_PMC_PRINT_PMEM_MAPPINGS;
+
+    /* head aligned */
+    VALGRIND_PMC_REMOVE_PMEM_MAPPING(0x100, 0x10);
+    VALGRIND_PMC_PRINT_PMEM_MAPPINGS;
+
+    /* tail aligned */
+    VALGRIND_PMC_REMOVE_PMEM_MAPPING(0x130, 0x10);
+    VALGRIND_PMC_PRINT_PMEM_MAPPINGS;
+
+    return 0;
+}

--- a/pmemcheck/tests/address_specific/remove_aligned_region.stderr.exp
+++ b/pmemcheck/tests/address_specific/remove_aligned_region.stderr.exp
@@ -1,0 +1,3 @@
+[0] Mapping base: 0x100	size: 64
+[0] Mapping base: 0x110	size: 48
+[0] Mapping base: 0x110	size: 32

--- a/pmemcheck/tests/address_specific/remove_aligned_region.vgtest
+++ b/pmemcheck/tests/address_specific/remove_aligned_region.vgtest
@@ -1,0 +1,2 @@
+prog: remove_aligned_region
+vgopts: -q --print-summary=no

--- a/pmemcheck/tests/address_specific/remove_regions.stderr.exp
+++ b/pmemcheck/tests/address_specific/remove_regions.stderr.exp
@@ -1,10 +1,10 @@
 [0] Mapping base: 0x100	size: 11
-[1] Mapping base: 0x121	size: 16
+[1] Mapping base: 0x121	size: 15
 [0] Mapping base: 0x100	size: 11
-[1] Mapping base: 0x121	size: 16
+[1] Mapping base: 0x121	size: 15
 [2] Mapping base: 0x140	size: 16
 [3] Mapping base: 0x160	size: 64
 [0] Mapping base: 0x100	size: 11
-[1] Mapping base: 0x121	size: 16
+[1] Mapping base: 0x121	size: 15
 [2] Mapping base: 0x140	size: 16
 [3] Mapping base: 0x160	size: 64


### PR DESCRIPTION
Head or tail aligned regions were removed completely instead of slicing.
