### PR TITLE
pmemcheck: add the SET_CLEAN macro

### DIFF
--- a/docs/html/FAQ.html
+++ b/docs/html/FAQ.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp60564560"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp58499616"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/docs/html/QuickStart.html
+++ b/docs/html/QuickStart.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp58252320"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp58559648"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/docs/html/dh-manual.html
+++ b/docs/html/dh-manual.html
@@ -26,9 +26,9 @@
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.overview">10.1. Overview</a></span></dt>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.understanding">10.2. Understanding DHAT's output</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="dh-manual.html#idp61561200">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp66561456">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp63518000">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp64873088">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63741552">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp64784112">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.options">10.3. DHAT Command-line Options</a></span></dt>
 </dl>
@@ -90,9 +90,9 @@ Most of the art of using it is in interpretation of the resulting
 numbers.  That is best illustrated via a set of examples.</p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idp61561200"></a>10.2.1. Interpreting the max-live, tot-alloc and deaths fields</h3></div></div></div>
+<a name="idp64873088"></a>10.2.1. Interpreting the max-live, tot-alloc and deaths fields</h3></div></div></div>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp61561904"></a>10.2.1.1. A simple example</h4></div></div></div></div>
+<a name="idp64873792"></a>10.2.1.1. A simple example</h4></div></div></div></div>
 <pre class="screen">
    ======== SUMMARY STATISTICS ========
 
@@ -123,7 +123,7 @@ instructions.  From the summary statistics we see that the program ran
 for 1,045,339,534 instructions, and so the average age at death is
 about 2% of the program's total run time.</p>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp65224304"></a>10.2.1.2. Example of a potential process-lifetime leak</h4></div></div></div></div>
+<a name="idp66614912"></a>10.2.1.2. Example of a potential process-lifetime leak</h4></div></div></div></div>
 <p>This next example (from a different program than the above)
 shows a potential process lifetime leak.  A process lifetime leak
 occurs when a program keeps allocating data, but only frees the
@@ -158,9 +158,9 @@ for the second half, and then freed just before exit.</p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idp66561456"></a>10.2.2. Interpreting the acc-ratios fields</h3></div></div></div>
+<a name="idp63741552"></a>10.2.2. Interpreting the acc-ratios fields</h3></div></div></div>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp66562208"></a>10.2.2.1. A fairly harmless allocation point record</h4></div></div></div></div>
+<a name="idp63742304"></a>10.2.2.1. A fairly harmless allocation point record</h4></div></div></div></div>
 <pre class="screen">
    max-live:    49,398 in 808 blocks
    tot-alloc:   1,481,940 in 24,240 blocks (avg size 61.13)
@@ -193,7 +193,7 @@ varying sizes, so DHAT can't perform such an analysis.  We can see
 that they must have varying sizes since the average block size, 61.13,
 isn't a whole number.</p>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp66470912"></a>10.2.2.2. A more suspicious looking example</h4></div></div></div></div>
+<a name="idp65986176"></a>10.2.2.2. A more suspicious looking example</h4></div></div></div></div>
 <pre class="screen">
    max-live:    180,224 in 22 blocks
    tot-alloc:   180,224 in 22 blocks (avg size 8192.00)
@@ -213,7 +213,7 @@ could be removed.</p>
 DHAT can tell us, that Memcheck can't, is that not only are the blocks
 leaked, they are also never used.</p>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp66581968"></a>10.2.2.3. Another suspicious example</h4></div></div></div></div>
+<a name="idp64265264"></a>10.2.2.3. Another suspicious example</h4></div></div></div></div>
 <p>Here's one where blocks are allocated, written to,
 but never read from.  We see this immediately from the zero read
 access ratio.  They do get freed, though:</p>
@@ -241,7 +241,7 @@ determine when those transitions are made.</p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idp63518000"></a>10.2.3. Interpreting "Aggregated access counts by offset" data</h3></div></div></div>
+<a name="idp64784112"></a>10.2.3. Interpreting "Aggregated access counts by offset" data</h3></div></div></div>
 <p>For allocation points that always allocate blocks of the same
 size, and which are 4096 bytes or smaller, DHAT counts accesses
 per offset, for example:</p>

--- a/docs/html/dist.html
+++ b/docs/html/dist.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp54110288"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp61920000"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/docs/html/faq.html
+++ b/docs/html/faq.html
@@ -187,7 +187,7 @@
 <tr><td colspan="2"> </td></tr>
 <tr class="question">
 <td align="left" valign="top">
-<a name="faq.glibc_devel"></a><a name="idp57765040"></a><b>2.2.</b>
+<a name="faq.glibc_devel"></a><a name="idp63619104"></a><b>2.2.</b>
 </td>
 <td align="left" valign="top">
 <b>When building Valgrind, 'make' fails with this:</b><pre class="screen">

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -19,7 +19,7 @@
         <a class="link" href="dist.authors.html" title="1. AUTHORS">AUTHORS</a>
       </p></div>
 <div align="center"><div class="legalnotice">
-<a name="idp51486960"></a><p>Permission is granted to copy, distribute and/or modify
+<a name="idp51488400"></a><p>Permission is granted to copy, distribute and/or modify
         this document under the terms of the GNU Free Documentation
         License, Version 1.2 or any later version published by the
         Free Software Foundation; with no Invariant Sections, with no

--- a/docs/html/manual.html
+++ b/docs/html/manual.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp65979760"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp64693248"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>
@@ -270,9 +270,9 @@ function</a></span></dt>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.overview">10.1. Overview</a></span></dt>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.understanding">10.2. Understanding DHAT's output</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="dh-manual.html#idp61561200">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp66561456">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp63518000">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp64873088">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63741552">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp64784112">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.options">10.3. DHAT Command-line Options</a></span></dt>
 </dl></dd>

--- a/docs/html/pmc-manual.html
+++ b/docs/html/pmc-manual.html
@@ -396,9 +396,18 @@ Stores flushed multiple times:
             registered persistent memory regions.
           </p></dd>
 <dt>
+<a name="crm.clean"></a><span class="term">
+	  <code class="option">VALGRIND_PMC_SET_CLEAN</code>
+	</span>
+</dt>
+<dd><p>
+	    Sets the desired region of persistent memory as clean. This may
+	    be useful for discarding changes made to persistent memory.
+          </p></dd>
+<dt>
 <a name="crm.wr_stats"></a><span class="term">
-		  <code class="option">VALGRIND_PMC_WRITE_STATS</code>
-		</span>
+	  <code class="option">VALGRIND_PMC_WRITE_STATS</code>
+	</span>
 </dt>
 <dd><p>
             Writes persistent memory analysis statistics.

--- a/docs/html/tech-docs.html
+++ b/docs/html/tech-docs.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp70417472"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp67477552"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/pmemcheck/docs/pmc-manual.xml
+++ b/pmemcheck/docs/pmc-manual.xml
@@ -436,15 +436,27 @@ Stores flushed multiple times:
 		</listitem>
 	  </varlistentry>
 
+      <varlistentry id="crm.clean" xreflabel="VALGRIND_PMC_SET_CLEAN">
+	<term>
+	  <option><![CDATA[VALGRIND_PMC_SET_CLEAN]]></option>
+	</term>
+	<listitem>
+	  <para>
+	    Sets the desired region of persistent memory as clean. This may
+	    be useful for discarding changes made to persistent memory.
+          </para>
+	</listitem>
+      </varlistentry>
+
       <varlistentry id="crm.wr_stats" xreflabel="VALGRIND_PMC_WRITE_STATS">
-	    <term>
-		  <option><![CDATA[VALGRIND_PMC_WRITE_STATS]]></option>
-		</term>
-		<listitem>
-		  <para>
+        <term>
+	  <option><![CDATA[VALGRIND_PMC_WRITE_STATS]]></option>
+	</term>
+	<listitem>
+	  <para>
             Writes persistent memory analysis statistics.
           </para>
-		</listitem>
+	</listitem>
       </varlistentry>
 
       <varlistentry id="crm.log_on" xreflabel="VALGRIND_PMC_LOG_STORES">

--- a/pmemcheck/pmc_main.c
+++ b/pmemcheck/pmc_main.c
@@ -239,6 +239,7 @@ remove_region(struct pmem_st *region, OSet *region_set)
             VG_(OSetGen_Insert)(region_set, modified_entry);
             struct pmem_st *new_region = VG_(OSetGen_AllocNode)(region_set,
                     sizeof (struct pmem_st));
+            *new_region = *modified_entry;
             new_region->addr = region_max_addr;
             new_region->size = mod_entry_max_addr - new_region->addr;
             VG_(OSetGen_Insert)(region_set, new_region);
@@ -1411,6 +1412,16 @@ pmc_handle_client_request(ThreadId tid, UWord *arg, UWord *ret )
             if (pmem.log_stores && (pmem.loggin_on || (VG_(OSetGen_Size)
                     (pmem.loggable_regions) != 0)))
                 VG_(emit)("|NO_REORDER_FAULT");
+            *ret = 1;
+            break;
+        }
+
+        case VG_USERREQ__PMC_SET_CLEAN: {
+            struct pmem_st temp_info;
+            temp_info.addr = arg[1];
+            temp_info.size = arg[2];
+
+            remove_region(&temp_info, pmem.pmem_stores);
             *ret = 1;
             break;
         }

--- a/pmemcheck/pmemcheck.h
+++ b/pmemcheck/pmemcheck.h
@@ -67,6 +67,7 @@ typedef
        VG_USERREQ__PMC_PARTIAL_REORDER,
        VG_USERREQ__PMC_ONLY_FAULT,
        VG_USERREQ__PMC_STOP_REORDER_FAULT,
+       VG_USERREQ__PMC_SET_CLEAN
    } Vg_PMemCheckClientRequest;
 
 
@@ -164,6 +165,12 @@ typedef
 #define VALGRIND_PMC_STOP_REORDER_FAULT                                     \
     VALGRIND_DO_CLIENT_REQUEST_STMT(VG_USERREQ__PMC_STOP_REORDER_FAULT,     \
                                     0, 0, 0, 0, 0)
+
+/** Remove a persistent memory mapping region */
+#define VALGRIND_PMC_SET_CLEAN(_qzz_addr,_qzz_len)                      \
+    VALGRIND_DO_CLIENT_REQUEST_EXPR(0 /* default return */,             \
+                            VG_USERREQ__PMC_SET_CLEAN,                  \
+                            (_qzz_addr), (_qzz_len), 0, 0, 0)
 
 #endif
 

--- a/pmemcheck/tests/Makefile.am
+++ b/pmemcheck/tests/Makefile.am
@@ -34,7 +34,8 @@ EXTRA_DIST = \
 	flush_check.stderr.exp flush_check.stdout.exp flush_check.vgtest \
 	state_no_flush_align.stderr.exp state_no_flush_align.stdout.exp \
 		state_no_flush_align.vgtest \
-	nt_stores.stderr.exp nt_stores.stdout.exp nt_stores.vgtest
+	nt_stores.stderr.exp nt_stores.stdout.exp nt_stores.vgtest \
+	set_clean.stderr.exp set_clean.stdout.exp set_clean.vgtest
 
 check_PROGRAMS = \
 	const_store \
@@ -46,4 +47,5 @@ check_PROGRAMS = \
 	cas \
 	flush_check \
 	state_no_flush_align \
-	nt_stores
+	nt_stores \
+	set_clean

--- a/pmemcheck/tests/set_clean.c
+++ b/pmemcheck/tests/set_clean.c
@@ -1,0 +1,56 @@
+/*
+ * Persistent memory checker.
+ * Copyright (c) 2014-2015, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, or (at your option) any later version, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#include "../pmemcheck.h"
+#include <stdint.h>
+
+static struct tester {
+    int64_t a;
+    int32_t b;
+    int32_t c;
+} Test_struct;
+
+int main ( void )
+{
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(&Test_struct, sizeof (Test_struct));
+
+    /* register some stores to the Test_struct */
+    Test_struct.a = 1;
+    Test_struct.b = 2;
+    Test_struct.c = 3;
+
+    /* set different state to the stores */
+    VALGRIND_PMC_DO_FLUSH(&(Test_struct.a), sizeof (Test_struct.a));
+    VALGRIND_PMC_DO_FENCE;
+    VALGRIND_PMC_DO_FLUSH(&(Test_struct.b), sizeof (Test_struct.b));
+
+    VALGRIND_PMC_WRITE_STATS;
+
+    /* start setting the Test_struct as clean */
+
+    int16_t *slice = &(Test_struct.b);
+    VALGRIND_PMC_SET_CLEAN(slice - 1, sizeof (int64_t));
+
+    VALGRIND_PMC_WRITE_STATS;
+
+    VALGRIND_PMC_SET_CLEAN(&(Test_struct.c), sizeof (Test_struct.c));
+
+    VALGRIND_PMC_WRITE_STATS;
+
+    VALGRIND_PMC_SET_CLEAN(&(Test_struct.a), sizeof (Test_struct.a));
+
+    VALGRIND_PMC_WRITE_STATS;
+
+    return 0;
+}

--- a/pmemcheck/tests/set_clean.stderr.exp
+++ b/pmemcheck/tests/set_clean.stderr.exp
@@ -1,0 +1,22 @@
+Number of stores not made persistent: 3
+Stores not made persistent properly:
+[0]    at 0x........: main (set_clean.c:29)
+	Address: 0x........	size: 8	state: FENCED
+[1]    at 0x........: main (set_clean.c:30)
+	Address: 0x........	size: 4	state: FLUSHED
+[2]    at 0x........: main (set_clean.c:31)
+	Address: 0x........	size: 4	state: DIRTY
+Total memory not made persistent: 16
+Number of stores not made persistent: 2
+Stores not made persistent properly:
+[0]    at 0x........: main (set_clean.c:29)
+	Address: 0x........	size: 6	state: FENCED
+[1]    at 0x........: main (set_clean.c:31)
+	Address: 0x........	size: 2	state: DIRTY
+Total memory not made persistent: 8
+Number of stores not made persistent: 1
+Stores not made persistent properly:
+[0]    at 0x........: main (set_clean.c:29)
+	Address: 0x........	size: 6	state: FENCED
+Total memory not made persistent: 6
+Number of stores not made persistent: 0

--- a/pmemcheck/tests/set_clean.vgtest
+++ b/pmemcheck/tests/set_clean.vgtest
@@ -1,0 +1,2 @@
+prog: set_clean
+vgopts: -q --print-summary=no


### PR DESCRIPTION
This enables discarding recorded changes made to persistent memory.
Updated and regenerated docs.

Refs pmem/valgrind#12
