### PR TITLE
pmemcheck: add unnecessary flush recording

### DIFF
--- a/docs/html/FAQ.html
+++ b/docs/html/FAQ.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp58499616"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp59506000"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/docs/html/QuickStart.html
+++ b/docs/html/QuickStart.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp58559648"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp59423504"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/docs/html/dh-manual.html
+++ b/docs/html/dh-manual.html
@@ -26,9 +26,9 @@
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.overview">10.1. Overview</a></span></dt>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.understanding">10.2. Understanding DHAT's output</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="dh-manual.html#idp64873088">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp63741552">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp64784112">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63506832">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63408752">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp65901984">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.options">10.3. DHAT Command-line Options</a></span></dt>
 </dl>
@@ -90,9 +90,9 @@ Most of the art of using it is in interpretation of the resulting
 numbers.  That is best illustrated via a set of examples.</p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idp64873088"></a>10.2.1. Interpreting the max-live, tot-alloc and deaths fields</h3></div></div></div>
+<a name="idp63506832"></a>10.2.1. Interpreting the max-live, tot-alloc and deaths fields</h3></div></div></div>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp64873792"></a>10.2.1.1. A simple example</h4></div></div></div></div>
+<a name="idp63507536"></a>10.2.1.1. A simple example</h4></div></div></div></div>
 <pre class="screen">
    ======== SUMMARY STATISTICS ========
 
@@ -123,7 +123,7 @@ instructions.  From the summary statistics we see that the program ran
 for 1,045,339,534 instructions, and so the average age at death is
 about 2% of the program's total run time.</p>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp66614912"></a>10.2.1.2. Example of a potential process-lifetime leak</h4></div></div></div></div>
+<a name="idp65645856"></a>10.2.1.2. Example of a potential process-lifetime leak</h4></div></div></div></div>
 <p>This next example (from a different program than the above)
 shows a potential process lifetime leak.  A process lifetime leak
 occurs when a program keeps allocating data, but only frees the
@@ -158,9 +158,9 @@ for the second half, and then freed just before exit.</p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idp63741552"></a>10.2.2. Interpreting the acc-ratios fields</h3></div></div></div>
+<a name="idp63408752"></a>10.2.2. Interpreting the acc-ratios fields</h3></div></div></div>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp63742304"></a>10.2.2.1. A fairly harmless allocation point record</h4></div></div></div></div>
+<a name="idp63409504"></a>10.2.2.1. A fairly harmless allocation point record</h4></div></div></div></div>
 <pre class="screen">
    max-live:    49,398 in 808 blocks
    tot-alloc:   1,481,940 in 24,240 blocks (avg size 61.13)
@@ -193,7 +193,7 @@ varying sizes, so DHAT can't perform such an analysis.  We can see
 that they must have varying sizes since the average block size, 61.13,
 isn't a whole number.</p>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp65986176"></a>10.2.2.2. A more suspicious looking example</h4></div></div></div></div>
+<a name="idp63935184"></a>10.2.2.2. A more suspicious looking example</h4></div></div></div></div>
 <pre class="screen">
    max-live:    180,224 in 22 blocks
    tot-alloc:   180,224 in 22 blocks (avg size 8192.00)
@@ -213,7 +213,7 @@ could be removed.</p>
 DHAT can tell us, that Memcheck can't, is that not only are the blocks
 leaked, they are also never used.</p>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp64265264"></a>10.2.2.3. Another suspicious example</h4></div></div></div></div>
+<a name="idp58988992"></a>10.2.2.3. Another suspicious example</h4></div></div></div></div>
 <p>Here's one where blocks are allocated, written to,
 but never read from.  We see this immediately from the zero read
 access ratio.  They do get freed, though:</p>
@@ -241,7 +241,7 @@ determine when those transitions are made.</p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idp64784112"></a>10.2.3. Interpreting "Aggregated access counts by offset" data</h3></div></div></div>
+<a name="idp65901984"></a>10.2.3. Interpreting "Aggregated access counts by offset" data</h3></div></div></div>
 <p>For allocation points that always allocate blocks of the same
 size, and which are 4096 bytes or smaller, DHAT counts accesses
 per offset, for example:</p>

--- a/docs/html/dist.html
+++ b/docs/html/dist.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp61920000"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp58726064"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/docs/html/faq.html
+++ b/docs/html/faq.html
@@ -187,7 +187,7 @@
 <tr><td colspan="2"> </td></tr>
 <tr class="question">
 <td align="left" valign="top">
-<a name="faq.glibc_devel"></a><a name="idp63619104"></a><b>2.2.</b>
+<a name="faq.glibc_devel"></a><a name="idp64641888"></a><b>2.2.</b>
 </td>
 <td align="left" valign="top">
 <b>When building Valgrind, 'make' fails with this:</b><pre class="screen">

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -19,7 +19,7 @@
         <a class="link" href="dist.authors.html" title="1. AUTHORS">AUTHORS</a>
       </p></div>
 <div align="center"><div class="legalnotice">
-<a name="idp51488400"></a><p>Permission is granted to copy, distribute and/or modify
+<a name="idp55324416"></a><p>Permission is granted to copy, distribute and/or modify
         this document under the terms of the GNU Free Documentation
         License, Version 1.2 or any later version published by the
         Free Software Foundation; with no Invariant Sections, with no

--- a/docs/html/manual.html
+++ b/docs/html/manual.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp64693248"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp57904960"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>
@@ -270,9 +270,9 @@ function</a></span></dt>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.overview">10.1. Overview</a></span></dt>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.understanding">10.2. Understanding DHAT's output</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="dh-manual.html#idp64873088">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp63741552">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp64784112">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63506832">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63408752">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp65901984">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.options">10.3. DHAT Command-line Options</a></span></dt>
 </dl></dd>

--- a/docs/html/pmc-manual.html
+++ b/docs/html/pmc-manual.html
@@ -141,12 +141,12 @@
 <pre class="programlisting">
 Number of stores not made persistent: 3
 Stores not made persistent properly:
-[0]    at 0x1234: main (state_machine2.c:28)
-	Address: 0x12345	size: 1	state: FENCED
-[1]    at 0x1235: main (state_machine2.c:31)
-	Address: 0x12346	size: 2	state: FLUSHED
-[2]    at 0x1236: main (state_machine2.c:33)
-	Address: 0x12347	size: 4	state: DIRTY
+[0]    at 0x400A73: main (state_machine2.c:29)
+	Address: 0x4fec000	size: 1	state: FENCED
+[1]    at 0x400B56: main (state_machine2.c:32)
+	Address: 0x4fec008	size: 2	state: FLUSHED
+[2]    at 0x400BB8: main (state_machine2.c:34)
+	Address: 0x4fec010	size: 4	state: DIRTY
 Total memory not made persistent: 7</pre>
 <p>
         This indicates that three stores made to persistent memory are not
@@ -173,18 +173,18 @@ Total memory not made persistent: 7</pre>
 <pre class="programlisting">
 Number of stores not made persistent: 1
 Stores not made persistent properly:
-[0]    at 0x1234: main (multiple_stores.c:33)
-	Address: 0x12345	size: 8	state: DIRTY
+[0]    at 0x400A89: main (multiple_stores.c:33)
+	Address: 0x4fec000	size: 8	state: DIRTY
 Total memory not made persistent: 8
 
 Number of overwritten stores: 3
 Overwritten stores before they were made persistent:
-[0]    at 0x1235: main (multiple_stores.c:30)
-	Address: 0x12345	size: 1	state: DIRTY
-[1]    at 0x1236: main (multiple_stores.c:31)
-	Address: 0x12345	size: 2	state: DIRTY
-[2]    at 0x1237: main (multiple_stores.c:32)
-	Address: 0x12345	size: 4	state: DIRTY</pre>
+[0]    at 0x400A6F: main (multiple_stores.c:30)
+	Address: 0x4fec000	size: 1	state: DIRTY
+[1]    at 0x400A76: main (multiple_stores.c:31)
+	Address: 0x4fec000	size: 2	state: DIRTY
+[2]    at 0x400A7F: main (multiple_stores.c:32)
+	Address: 0x4fec000	size: 4	state: DIRTY</pre>
 <p>
         If the values or sizes are different, or the stores overlap somehow,
         the event will be recorded regardless of the
@@ -199,23 +199,31 @@ Overwritten stores before they were made persistent:
         output from the flush checking analysis can look like this:
         </p>
 <pre class="programlisting">
-Number of stores not made persistent: 1
-Stores not made persistent properly:
-[0]    at 0x........: main (flush_check.c:27)
-	Address: 0x........	size: 8	state: COMMITTED
-Total memory not made persistent: 8
-
-Number of multiply flushed stores: 3
+Number of redundantly flushed stores: 3
 Stores flushed multiple times:
-[0]    at 0x........: main (flush_check.c:27)
-	Address: 0x........	size: 8	state: FLUSHED
-[1]    at 0x........: main (flush_check.c:27)
-	Address: 0x........	size: 8	state: FENCED
-[2]    at 0x........: main (flush_check.c:27)
-	Address: 0x........	size: 8	state: COMMITTED</pre>
+[0]    at 0x400A5B: main (flush_check.c:27)
+	Address: 0x4fec000	size: 8	state: FLUSHED
+[1]    at 0x400A5B: main (flush_check.c:27)
+	Address: 0x4fec000	size: 8	state: FENCED
+[2]    at 0x400A5B: main (flush_check.c:27)
+	Address: 0x4fec000	size: 8	state: COMMITTED</pre>
 <p>
         It indicates that the same store has been flushed multiple times,
         which is a potential performance issue.
+      </p>
+<p>
+	In case when no stores were made to the flushed region, the program will
+	yield the following output:
+	</p>
+<pre class="programlisting">
+Number of unnecessary flushes: 3
+[0]    at 0x400AB2: main (missed_flush.c:27)
+	Address: 0x4fec000	size: 64
+[1]    at 0x400B18: main (missed_flush.c:29)
+	Address: 0x4fec040	size: 128
+[2]    at 0x400B71: main (missed_flush.c:31)
+	Address: 0x0	size: 64</pre>
+<p>
       </p>
 </div>
 </div>

--- a/docs/html/tech-docs.html
+++ b/docs/html/tech-docs.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp67477552"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp66999024"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/pmemcheck/docs/pmc-manual.xml
+++ b/pmemcheck/docs/pmc-manual.xml
@@ -132,12 +132,12 @@
         <programlisting><![CDATA[
 Number of stores not made persistent: 3
 Stores not made persistent properly:
-[0]    at 0x1234: main (state_machine2.c:28)
-	Address: 0x12345	size: 1	state: FENCED
-[1]    at 0x1235: main (state_machine2.c:31)
-	Address: 0x12346	size: 2	state: FLUSHED
-[2]    at 0x1236: main (state_machine2.c:33)
-	Address: 0x12347	size: 4	state: DIRTY
+[0]    at 0x400A73: main (state_machine2.c:29)
+	Address: 0x4fec000	size: 1	state: FENCED
+[1]    at 0x400B56: main (state_machine2.c:32)
+	Address: 0x4fec008	size: 2	state: FLUSHED
+[2]    at 0x400BB8: main (state_machine2.c:34)
+	Address: 0x4fec010	size: 4	state: DIRTY
 Total memory not made persistent: 7]]></programlisting>
         This indicates that three stores made to persistent memory are not
         guaranteed to be durable in case of power failure. The offending stores
@@ -163,18 +163,18 @@ Total memory not made persistent: 7]]></programlisting>
         output:<programlisting><![CDATA[
 Number of stores not made persistent: 1
 Stores not made persistent properly:
-[0]    at 0x1234: main (multiple_stores.c:33)
-	Address: 0x12345	size: 8	state: DIRTY
+[0]    at 0x400A89: main (multiple_stores.c:33)
+	Address: 0x4fec000	size: 8	state: DIRTY
 Total memory not made persistent: 8
 
 Number of overwritten stores: 3
 Overwritten stores before they were made persistent:
-[0]    at 0x1235: main (multiple_stores.c:30)
-	Address: 0x12345	size: 1	state: DIRTY
-[1]    at 0x1236: main (multiple_stores.c:31)
-	Address: 0x12345	size: 2	state: DIRTY
-[2]    at 0x1237: main (multiple_stores.c:32)
-	Address: 0x12345	size: 4	state: DIRTY]]></programlisting>
+[0]    at 0x400A6F: main (multiple_stores.c:30)
+	Address: 0x4fec000	size: 1	state: DIRTY
+[1]    at 0x400A76: main (multiple_stores.c:31)
+	Address: 0x4fec000	size: 2	state: DIRTY
+[2]    at 0x400A7F: main (multiple_stores.c:32)
+	Address: 0x4fec000	size: 4	state: DIRTY]]></programlisting>
         If the values or sizes are different, or the stores overlap somehow,
         the event will be recorded regardless of the
         <xref linkend="opt.indiff"/> value.
@@ -188,22 +188,28 @@ Overwritten stores before they were made persistent:
         It reports all occurences of flushes made on non-dirty cache lines. The
         output from the flush checking analysis can look like this:
         <programlisting><![CDATA[
-Number of stores not made persistent: 1
-Stores not made persistent properly:
-[0]    at 0x........: main (flush_check.c:27)
-	Address: 0x........	size: 8	state: COMMITTED
-Total memory not made persistent: 8
-
-Number of multiply flushed stores: 3
+Number of redundantly flushed stores: 3
 Stores flushed multiple times:
-[0]    at 0x........: main (flush_check.c:27)
-	Address: 0x........	size: 8	state: FLUSHED
-[1]    at 0x........: main (flush_check.c:27)
-	Address: 0x........	size: 8	state: FENCED
-[2]    at 0x........: main (flush_check.c:27)
-	Address: 0x........	size: 8	state: COMMITTED]]></programlisting>
+[0]    at 0x400A5B: main (flush_check.c:27)
+	Address: 0x4fec000	size: 8	state: FLUSHED
+[1]    at 0x400A5B: main (flush_check.c:27)
+	Address: 0x4fec000	size: 8	state: FENCED
+[2]    at 0x400A5B: main (flush_check.c:27)
+	Address: 0x4fec000	size: 8	state: COMMITTED]]></programlisting>
         It indicates that the same store has been flushed multiple times,
         which is a potential performance issue.
+      </para>
+      <para>
+	In case when no stores were made to the flushed region, the program will
+	yield the following output:
+	<programlisting><![CDATA[
+Number of unnecessary flushes: 3
+[0]    at 0x400AB2: main (missed_flush.c:27)
+	Address: 0x4fec000	size: 64
+[1]    at 0x400B18: main (missed_flush.c:29)
+	Address: 0x4fec040	size: 128
+[2]    at 0x400B71: main (missed_flush.c:31)
+	Address: 0x0	size: 64]]></programlisting>
       </para>
 
     </sect2>

--- a/pmemcheck/tests/Makefile.am
+++ b/pmemcheck/tests/Makefile.am
@@ -35,7 +35,8 @@ EXTRA_DIST = \
 	state_no_flush_align.stderr.exp state_no_flush_align.stdout.exp \
 		state_no_flush_align.vgtest \
 	nt_stores.stderr.exp nt_stores.stdout.exp nt_stores.vgtest \
-	set_clean.stderr.exp set_clean.stdout.exp set_clean.vgtest
+	set_clean.stderr.exp set_clean.stdout.exp set_clean.vgtest \
+	missed_flush.stderr.exp missed_flush.stdout.exp missed_flush.vgtest
 
 check_PROGRAMS = \
 	const_store \
@@ -48,4 +49,5 @@ check_PROGRAMS = \
 	flush_check \
 	state_no_flush_align \
 	nt_stores \
-	set_clean
+	set_clean \
+	missed_flush

--- a/pmemcheck/tests/flush_check.stderr.exp
+++ b/pmemcheck/tests/flush_check.stderr.exp
@@ -4,7 +4,7 @@ Stores not made persistent properly:
 	Address: 0x........	size: 8	state: COMMITTED
 Total memory not made persistent: 8
 
-Number of multiply flushed stores: 3
+Number of redundantly flushed stores: 3
 Stores flushed multiple times:
 [0]    at 0x........: main (flush_check.c:27)
 	Address: 0x........	size: 8	state: FLUSHED

--- a/pmemcheck/tests/missed_flush.c
+++ b/pmemcheck/tests/missed_flush.c
@@ -1,0 +1,33 @@
+/*
+ * Persistent memory checker.
+ * Copyright (c) 2014-2015, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, or (at your option) any later version, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#include <stdint.h>
+
+#include "common.h"
+
+#define FILE_SIZE (16 * 1024 * 1024)
+
+int main ( void )
+{
+    /* make, map and register a temporary file */
+    void *base = make_map_tmpfile(FILE_SIZE);
+
+    /* flush should be registered as superfluous */
+    VALGRIND_PMC_DO_FLUSH(base, 64);
+    /* flush should be registered as superfluous */
+    VALGRIND_PMC_DO_FLUSH((uintptr_t)base + 64, 65);
+    /* flush should be registered as superfluous */
+    VALGRIND_PMC_DO_FLUSH(0, 64);
+    return 0;
+}

--- a/pmemcheck/tests/missed_flush.stderr.exp
+++ b/pmemcheck/tests/missed_flush.stderr.exp
@@ -1,0 +1,9 @@
+Number of stores not made persistent: 0
+
+Number of unnecessary flushes: 3
+[0]    at 0x........: main (missed_flush.c:27)
+	Address: 0x........	size: 64
+[1]    at 0x........: main (missed_flush.c:29)
+	Address: 0x........	size: 128
+[2]    at 0x........: main (missed_flush.c:31)
+	Address: 0x........	size: 64

--- a/pmemcheck/tests/missed_flush.vgtest
+++ b/pmemcheck/tests/missed_flush.vgtest
@@ -1,0 +1,2 @@
+prog: missed_flush
+vgopts: -q --flush-check=yes --flush-align=yes


### PR DESCRIPTION
Flushes made to memory regions, where no stores were made, will be
reported as superfluous.
