### PR TITLE
pmemchek: add caching of last region

### DIFF
--- a/docs/html/FAQ.html
+++ b/docs/html/FAQ.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp68318112"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp64282448"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/docs/html/QuickStart.html
+++ b/docs/html/QuickStart.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp60778928"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp57961152"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/docs/html/dh-manual.html
+++ b/docs/html/dh-manual.html
@@ -26,9 +26,9 @@
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.overview">10.1. Overview</a></span></dt>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.understanding">10.2. Understanding DHAT's output</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="dh-manual.html#idp65699216">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp69474384">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp69433712">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63403072">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63468400">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp61577168">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.options">10.3. DHAT Command-line Options</a></span></dt>
 </dl>
@@ -90,9 +90,9 @@ Most of the art of using it is in interpretation of the resulting
 numbers.  That is best illustrated via a set of examples.</p>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idp65699216"></a>10.2.1. Interpreting the max-live, tot-alloc and deaths fields</h3></div></div></div>
+<a name="idp63403072"></a>10.2.1. Interpreting the max-live, tot-alloc and deaths fields</h3></div></div></div>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp65699920"></a>10.2.1.1. A simple example</h4></div></div></div></div>
+<a name="idp63403776"></a>10.2.1.1. A simple example</h4></div></div></div></div>
 <pre class="screen">
    ======== SUMMARY STATISTICS ========
 
@@ -123,7 +123,7 @@ instructions.  From the summary statistics we see that the program ran
 for 1,045,339,534 instructions, and so the average age at death is
 about 2% of the program's total run time.</p>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp66930112"></a>10.2.1.2. Example of a potential process-lifetime leak</h4></div></div></div></div>
+<a name="idp62231072"></a>10.2.1.2. Example of a potential process-lifetime leak</h4></div></div></div></div>
 <p>This next example (from a different program than the above)
 shows a potential process lifetime leak.  A process lifetime leak
 occurs when a program keeps allocating data, but only frees the
@@ -158,9 +158,9 @@ for the second half, and then freed just before exit.</p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idp69474384"></a>10.2.2. Interpreting the acc-ratios fields</h3></div></div></div>
+<a name="idp63468400"></a>10.2.2. Interpreting the acc-ratios fields</h3></div></div></div>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp69475136"></a>10.2.2.1. A fairly harmless allocation point record</h4></div></div></div></div>
+<a name="idp68926080"></a>10.2.2.1. A fairly harmless allocation point record</h4></div></div></div></div>
 <pre class="screen">
    max-live:    49,398 in 808 blocks
    tot-alloc:   1,481,940 in 24,240 blocks (avg size 61.13)
@@ -193,7 +193,7 @@ varying sizes, so DHAT can't perform such an analysis.  We can see
 that they must have varying sizes since the average block size, 61.13,
 isn't a whole number.</p>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp65973168"></a>10.2.2.2. A more suspicious looking example</h4></div></div></div></div>
+<a name="idp61537840"></a>10.2.2.2. A more suspicious looking example</h4></div></div></div></div>
 <pre class="screen">
    max-live:    180,224 in 22 blocks
    tot-alloc:   180,224 in 22 blocks (avg size 8192.00)
@@ -213,7 +213,7 @@ could be removed.</p>
 DHAT can tell us, that Memcheck can't, is that not only are the blocks
 leaked, they are also never used.</p>
 <div class="sect3"><div class="titlepage"><div><div><h4 class="title">
-<a name="idp68691280"></a>10.2.2.3. Another suspicious example</h4></div></div></div></div>
+<a name="idp66481888"></a>10.2.2.3. Another suspicious example</h4></div></div></div></div>
 <p>Here's one where blocks are allocated, written to,
 but never read from.  We see this immediately from the zero read
 access ratio.  They do get freed, though:</p>
@@ -241,7 +241,7 @@ determine when those transitions are made.</p>
 </div>
 <div class="sect2">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="idp69433712"></a>10.2.3. Interpreting "Aggregated access counts by offset" data</h3></div></div></div>
+<a name="idp61577168"></a>10.2.3. Interpreting "Aggregated access counts by offset" data</h3></div></div></div>
 <p>For allocation points that always allocate blocks of the same
 size, and which are 4096 bytes or smaller, DHAT counts accesses
 per offset, for example:</p>

--- a/docs/html/dist.html
+++ b/docs/html/dist.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp61288448"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp57726192"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/docs/html/faq.html
+++ b/docs/html/faq.html
@@ -187,7 +187,7 @@
 <tr><td colspan="2"> </td></tr>
 <tr class="question">
 <td align="left" valign="top">
-<a name="faq.glibc_devel"></a><a name="idp67505328"></a><b>2.2.</b>
+<a name="faq.glibc_devel"></a><a name="idp57977792"></a><b>2.2.</b>
 </td>
 <td align="left" valign="top">
 <b>When building Valgrind, 'make' fails with this:</b><pre class="screen">

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -19,7 +19,7 @@
         <a class="link" href="dist.authors.html" title="1. AUTHORS">AUTHORS</a>
       </p></div>
 <div align="center"><div class="legalnotice">
-<a name="idp53663328"></a><p>Permission is granted to copy, distribute and/or modify
+<a name="idp56448944"></a><p>Permission is granted to copy, distribute and/or modify
         this document under the terms of the GNU Free Documentation
         License, Version 1.2 or any later version published by the
         Free Software Foundation; with no Invariant Sections, with no

--- a/docs/html/manual.html
+++ b/docs/html/manual.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp64092944"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp65663856"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>
@@ -270,9 +270,9 @@ function</a></span></dt>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.overview">10.1. Overview</a></span></dt>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.understanding">10.2. Understanding DHAT's output</a></span></dt>
 <dd><dl>
-<dt><span class="sect2"><a href="dh-manual.html#idp65699216">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp69474384">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
-<dt><span class="sect2"><a href="dh-manual.html#idp69433712">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63403072">10.2.1. Interpreting the max-live, tot-alloc and deaths fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp63468400">10.2.2. Interpreting the acc-ratios fields</a></span></dt>
+<dt><span class="sect2"><a href="dh-manual.html#idp61577168">10.2.3. Interpreting "Aggregated access counts by offset" data</a></span></dt>
 </dl></dd>
 <dt><span class="sect1"><a href="dh-manual.html#dh-manual.options">10.3. DHAT Command-line Options</a></span></dt>
 </dl></dd>

--- a/docs/html/pmc-manual.html
+++ b/docs/html/pmc-manual.html
@@ -517,8 +517,7 @@ Overlapping regions:
             Checks if a given regions is registered as a persistent memory
             mapping in pmemcheck. Returns <code class="computeroutput">0</code>
             if not, <code class="computeroutput">1</code> if fully within mapping,
-            <code class="computeroutput">2</code> if front overlaps and
-            <code class="computeroutput">3</code> if tail overlaps.
+            <code class="computeroutput">2</code> otherwise.
           </p></dd>
 <dt>
 <a name="crm.print_map"></a><span class="term">
@@ -707,7 +706,9 @@ Overlapping regions:
             issue. Returns <code class="computeroutput">1</code> when no matching
             transaction was found, <code class="computeroutput">2</code> when
             the current thread does not participate in this transaction and
-            <code class="computeroutput">0</code> otherwise.
+            <code class="computeroutput">0</code> otherwise. Multiple additions
+	    of the same region do not result in multiple region entries. They
+	    are registered as contiguous space and not separate enteties.
           </p></dd>
 <dt>
 <a name="crm.add_to_tx_n"></a><span class="term">
@@ -721,7 +722,9 @@ Overlapping regions:
             issue. Returns <code class="computeroutput">1</code> when no matching
             transaction was found, <code class="computeroutput">2</code> when
             the current thread does not participate in this transaction and
-            <code class="computeroutput">0</code> otherwise.
+            <code class="computeroutput">0</code> otherwise. Multiple additions
+	    of the same region do not result in multiple region entries. They
+	    are registered as contiguous space and not separate enteties.
           </p></dd>
 <dt>
 <a name="crm.remove_from_tx"></a><span class="term">
@@ -733,7 +736,9 @@ Overlapping regions:
             Returns <code class="computeroutput">1</code> when no matching
             transaction was found, <code class="computeroutput">2</code> when
             the current thread does not participate in this transaction and
-            <code class="computeroutput">0</code> otherwise.
+            <code class="computeroutput">0</code> otherwise. Removing a region once
+	    removes it from the transaction, regardless how many times it was
+	    added.
           </p></dd>
 <dt>
 <a name="crm.remove_from_tx_n"></a><span class="term">
@@ -745,7 +750,9 @@ Overlapping regions:
             Returns <code class="computeroutput">1</code> when no matching
             transaction was found, <code class="computeroutput">2</code> when
             the current thread does not participate in this transaction and
-            <code class="computeroutput">0</code> otherwise.
+            <code class="computeroutput">0</code> otherwise. Removing a region once
+	    removes it from the transaction, regardless how many times it was
+	    added.
           </p></dd>
 <dt>
 <a name="crm.add_thread_to_tx_n"></a><span class="term">

--- a/docs/html/tech-docs.html
+++ b/docs/html/tech-docs.html
@@ -25,7 +25,7 @@
 <div><p class="releaseinfo">Release 3.10.0 10 September 2014</p></div>
 <div><p class="copyright">Copyright © 2000-2014 <a class="ulink" href="http://www.valgrind.org/info/developers.html" target="_top">Valgrind Developers</a></p></div>
 <div><div class="legalnotice">
-<a name="idp72404128"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
+<a name="idp66645968"></a><p>Email: <a class="ulink" href="mailto:valgrind@valgrind.org" target="_top">valgrind@valgrind.org</a></p>
 </div></div>
 </div>
 <hr>

--- a/pmemcheck/docs/pmc-manual.xml
+++ b/pmemcheck/docs/pmc-manual.xml
@@ -547,8 +547,7 @@ Overlapping regions:
             Checks if a given regions is registered as a persistent memory
             mapping in pmemcheck. Returns <computeroutput>0</computeroutput>
             if not, <computeroutput>1</computeroutput> if fully within mapping,
-            <computeroutput>2</computeroutput> if front overlaps and
-            <computeroutput>3</computeroutput> if tail overlaps.
+            <computeroutput>2</computeroutput> otherwise.
           </para>
 		</listitem>
 	  </varlistentry>
@@ -794,7 +793,9 @@ Overlapping regions:
             issue. Returns <computeroutput>1</computeroutput> when no matching
             transaction was found, <computeroutput>2</computeroutput> when
             the current thread does not participate in this transaction and
-            <computeroutput>0</computeroutput> otherwise.
+            <computeroutput>0</computeroutput> otherwise. Multiple additions
+	    of the same region do not result in multiple region entries. They
+	    are registered as contiguous space and not separate enteties.
           </para>
         </listitem>
       </varlistentry>
@@ -811,7 +812,9 @@ Overlapping regions:
             issue. Returns <computeroutput>1</computeroutput> when no matching
             transaction was found, <computeroutput>2</computeroutput> when
             the current thread does not participate in this transaction and
-            <computeroutput>0</computeroutput> otherwise.
+            <computeroutput>0</computeroutput> otherwise. Multiple additions
+	    of the same region do not result in multiple region entries. They
+	    are registered as contiguous space and not separate enteties.
           </para>
         </listitem>
       </varlistentry>
@@ -826,7 +829,9 @@ Overlapping regions:
             Returns <computeroutput>1</computeroutput> when no matching
             transaction was found, <computeroutput>2</computeroutput> when
             the current thread does not participate in this transaction and
-            <computeroutput>0</computeroutput> otherwise.
+            <computeroutput>0</computeroutput> otherwise. Removing a region once
+	    removes it from the transaction, regardless how many times it was
+	    added.
           </para>
         </listitem>
       </varlistentry>
@@ -841,7 +846,9 @@ Overlapping regions:
             Returns <computeroutput>1</computeroutput> when no matching
             transaction was found, <computeroutput>2</computeroutput> when
             the current thread does not participate in this transaction and
-            <computeroutput>0</computeroutput> otherwise.
+            <computeroutput>0</computeroutput> otherwise. Removing a region once
+	    removes it from the transaction, regardless how many times it was
+	    added.
           </para>
         </listitem>
       </varlistentry>

--- a/pmemcheck/pmc_include.h
+++ b/pmemcheck/pmc_include.h
@@ -49,9 +49,11 @@ void remove_region(const struct pmem_st *region, OSet *region_set);
 Word cmp_pmem_st(const void *key, const void *elem);
 
 /* Check and update the given warning event register. */
-void
-add_warning_event(struct pmem_st **event_register, UWord *nevents,
+void add_warning_event(struct pmem_st **event_register, UWord *nevents,
                   struct pmem_st *event, UWord limit, void (*err_msg)(UWord));
+
+/* Check if regions overlap */
+UWord check_overlap(const struct pmem_st *lhs, const struct pmem_st *rhs);
 
 /*------------------------------------------------------------*/
 /*--- Transactions related                                 ---*/

--- a/pmemcheck/pmc_main.c
+++ b/pmemcheck/pmc_main.c
@@ -1536,7 +1536,7 @@ pmc_post_clo_init(void)
     init_transactions(pmem.transactions_only);
 
     if (pmem.log_stores)
-        VG_(umsg)("START");
+        VG_(emit)("START");
 }
 
 /**
@@ -1581,7 +1581,7 @@ static void
 pmc_fini(Int exitcode)
 {
     if (pmem.log_stores)
-        VG_(umsg)("|STOP\n");
+        VG_(emit)("|STOP\n");
 
     if (pmem.print_summary)
         print_pmem_stats(False);

--- a/pmemcheck/tests/Makefile.am
+++ b/pmemcheck/tests/Makefile.am
@@ -40,7 +40,9 @@ EXTRA_DIST = \
 	trans_impl_nest.stderr.exp trans_impl_nest.vgtest \
 	trans_no_pmem.stderr.exp trans_no_pmem.vgtest \
 	trans_excl.stderr.exp trans_excl.vgtest \
-	trans_only.stderr.exp trans_only.vgtest
+	trans_only.stderr.exp trans_only.vgtest \
+	trans_cache_overl.stderr.exp trans_cache_overl.vgtest \
+	trans_cache_flush.stderr.exp trans_cache_flush.vgtest
 
 check_PROGRAMS = \
 	const_store \
@@ -61,4 +63,6 @@ check_PROGRAMS = \
 	trans_impl_nest \
 	trans_no_pmem \
 	trans_excl \
-	trans_only
+	trans_only \
+	trans_cache_overl \
+	trans_cache_flush

--- a/pmemcheck/tests/trans_cache_flush.c
+++ b/pmemcheck/tests/trans_cache_flush.c
@@ -1,0 +1,47 @@
+/*
+ * Persistent memory checker.
+ * Copyright (c) 2015, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, or (at your option) any later version, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#include "common.h"
+#include <stdint.h>
+
+#define FILE_SIZE (16 * 1024 * 1024)
+
+int main ( void )
+{
+    /* make, map and register a temporary file */
+    void *base = make_map_tmpfile(FILE_SIZE);
+
+    int16_t *i16p = base;
+    int64_t *i64p = base;
+
+    VALGRIND_PMC_START_TX_N(1234);
+
+    /* first three should be merged, fourth cached */
+    VALGRIND_PMC_ADD_TO_TX_N(1234, i16p, sizeof (*i16p));
+    ++i16p;
+    VALGRIND_PMC_ADD_TO_TX_N(1234, i16p, sizeof (*i16p));
+    ++i16p;
+    VALGRIND_PMC_ADD_TO_TX_N(1234, i16p, sizeof (*i16p));
+    ++i16p;
+    VALGRIND_PMC_ADD_TO_TX_N(1234, i16p, sizeof (*i16p));
+
+    /* trigger flush + merge on write */
+    *i64p = 9;
+    /* ignore persistency related errors */
+    VALGRIND_PMC_SET_CLEAN(i64p, sizeof (*i64p));
+
+    VALGRIND_PMC_END_TX_N(1234);
+
+    return 0;
+}

--- a/pmemcheck/tests/trans_cache_flush.stderr.exp
+++ b/pmemcheck/tests/trans_cache_flush.stderr.exp
@@ -1,0 +1,1 @@
+Number of stores not made persistent: 0

--- a/pmemcheck/tests/trans_cache_flush.vgtest
+++ b/pmemcheck/tests/trans_cache_flush.vgtest
@@ -1,0 +1,2 @@
+prog: trans_cache_flush
+vgopts: -q

--- a/pmemcheck/tests/trans_cache_overl.c
+++ b/pmemcheck/tests/trans_cache_overl.c
@@ -1,0 +1,53 @@
+/*
+ * Persistent memory checker.
+ * Copyright (c) 2015, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, or (at your option) any later version, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#include "common.h"
+#include <stdint.h>
+
+#define FILE_SIZE (16 * 1024 * 1024)
+
+int main ( void )
+{
+    /* make, map and register a temporary file */
+    void *base = make_map_tmpfile(FILE_SIZE);
+
+    int32_t *i32p = base;
+    int8_t *i8p = i32p;
+
+    VALGRIND_PMC_START_TX_N(1234);
+    VALGRIND_PMC_START_TX_N(12345);
+
+    VALGRIND_PMC_ADD_TO_TX_N(1234, i32p, sizeof (*i32p));
+    VALGRIND_PMC_ADD_TO_TX_N(12345, i8p, sizeof (*i8p));
+
+    VALGRIND_PMC_END_TX_N(12345);
+
+    VALGRIND_PMC_REMOVE_FROM_TX_N(1234, i32p, sizeof (*i32p));
+    /* add two adjacent regions within i32p */
+    VALGRIND_PMC_ADD_TO_TX_N(1234, i8p, sizeof (*i8p));
+    ++i8p;
+    VALGRIND_PMC_ADD_TO_TX_N(1234, i8p, sizeof (*i8p));
+
+    /* after this add, only cache should be present */
+    VALGRIND_PMC_ADD_TO_TX_N(1234, i32p, sizeof (*i32p));
+    /* clear cache - no more regions within this transaction */
+    VALGRIND_PMC_REMOVE_FROM_TX_N(1234, i32p, sizeof (*i32p));
+    /* make store within i32p where a region was previously registered */
+    *i8p = 42;
+
+    VALGRIND_PMC_END_TX_N(1234);
+
+
+    return 0;
+}

--- a/pmemcheck/tests/trans_cache_overl.stderr.exp
+++ b/pmemcheck/tests/trans_cache_overl.stderr.exp
@@ -1,0 +1,18 @@
+Number of stores not made persistent: 1
+Stores not made persistent properly:
+[0]    at 0x........: main (trans_cache_overl.c:47)
+	Address: 0x........	size: 1	state: DIRTY
+Total memory not made persistent: 1
+
+Number of stores made outside of transactions: 1
+Stores made outside of transactions:
+[0]    at 0x........: main (trans_cache_overl.c:47)
+	Address: 0x........	size: 1
+
+Number of overlapping regions registered in different transactions: 1
+Overlapping regions:
+[0]    at 0x........: main (trans_cache_overl.c:32)
+	Address: 0x........	size: 1	tx_id: ...
+   First registered here:
+[0]'   at 0x........: main (trans_cache_overl.c:31)
+	Address: 0x........	size: 4	tx_id: ...

--- a/pmemcheck/tests/trans_cache_overl.vgtest
+++ b/pmemcheck/tests/trans_cache_overl.vgtest
@@ -1,0 +1,2 @@
+prog: trans_cache_overl
+vgopts: -q

--- a/pmemcheck/tests/trans_no_pmem.c
+++ b/pmemcheck/tests/trans_no_pmem.c
@@ -16,8 +16,6 @@
 
 #include "../pmemcheck.h"
 
-#define FILE_SIZE (16 * 1024 * 1024)
-
 int main ( void )
 {
 
@@ -29,7 +27,6 @@ int main ( void )
     VALGRIND_PMC_START_TX;
 
     VALGRIND_PMC_ADD_TO_TX(&i16, sizeof (i16));
-    /* dirty stores */
     i16 = 2;
 
     VALGRIND_PMC_ADD_TO_TX(&i8, sizeof (i8));

--- a/pmemcheck/tests/trans_no_pmem.stderr.exp
+++ b/pmemcheck/tests/trans_no_pmem.stderr.exp
@@ -1,20 +1,20 @@
 Number of stores not made persistent: 1
 Stores not made persistent properly:
-[0]    at 0x........: main (trans_no_pmem.c:36)
+[0]    at 0x........: main (trans_no_pmem.c:33)
 	Address: 0x........	size: 1	state: DIRTY
 Total memory not made persistent: 1
 
 Number of active transactions: 1
-[0]    at 0x........: main (trans_no_pmem.c:29)
+[0]    at 0x........: main (trans_no_pmem.c:27)
 	tx_id: ...	 nesting: 1
 
 Number of stores not made persistent: 1
 Stores not made persistent properly:
-[0]    at 0x........: main (trans_no_pmem.c:44)
+[0]    at 0x........: main (trans_no_pmem.c:41)
 	Address: 0x........	size: 1	state: DIRTY
 Total memory not made persistent: 1
 
 Number of stores made outside of transactions: 1
 Stores made outside of transactions:
-[0]    at 0x........: main (trans_no_pmem.c:44)
+[0]    at 0x........: main (trans_no_pmem.c:41)
 	Address: 0x........	size: 1


### PR DESCRIPTION
When adding a region to a transaction, the last value is cached to
optimize temporary additions.
