### PR TITLE
Fix crash when user allocates in recently freed space and touches noaccess space close to it.

### DIFF
--- a/memcheck/tests/mempool2.c
+++ b/memcheck/tests/mempool2.c
@@ -183,6 +183,18 @@ void test(void)
    // claim res is used, so gcc can't nuke this all
    __asm__ __volatile__("" : : "r"(res));
 
+   {
+      char tmp[100];
+      VALGRIND_CREATE_MEMPOOL(tmp, 0, 0);
+      VALGRIND_MEMPOOL_ALLOC(tmp, tmp + 8, 16);
+      VALGRIND_MEMPOOL_FREE(tmp, tmp + 8);
+      VALGRIND_MEMPOOL_ALLOC(tmp, tmp + 8, 16);
+      VALGRIND_MAKE_MEM_NOACCESS(tmp, 8);
+      fprintf(stderr,
+              "\n------ write to noaccess space close to reallocated object ------\n\n");
+      tmp[7] = 0x66;
+   }
+
    fprintf(stderr,
            "\n------ done ------\n\n");
    pop(p1, 0);

--- a/memcheck/tests/mempool2.stderr.exp
+++ b/memcheck/tests/mempool2.stderr.exp
@@ -3,57 +3,57 @@
 
 Invalid read of size 1
    at 0x........: test (mempool2.c:135)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is 1 bytes before a block of size 10 client-defined
    at 0x........: allocate (mempool2.c:108)
    by 0x........: test (mempool2.c:130)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
 
 Invalid read of size 1
    at 0x........: test (mempool2.c:136)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is 0 bytes after a block of size 10 client-defined
    at 0x........: allocate (mempool2.c:108)
    by 0x........: test (mempool2.c:130)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
 
 
 ------ out of range reads in mmap-backed pool ------
 
 Invalid read of size 1
    at 0x........: test (mempool2.c:140)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is 1 bytes before a block of size 20 client-defined
    at 0x........: allocate (mempool2.c:108)
    by 0x........: test (mempool2.c:131)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
 
 Invalid read of size 1
    at 0x........: test (mempool2.c:141)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is 0 bytes after a block of size 20 client-defined
    at 0x........: allocate (mempool2.c:108)
    by 0x........: test (mempool2.c:131)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
 
 
 ------ read free in malloc-backed pool ------
 
 Illegal memory pool address
    at 0x........: test (mempool2.c:145)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is 0 bytes inside a block of size 32 alloc'd
    at 0x........: malloc (vg_replace_malloc.c:...)
    by 0x........: make_pool (mempool2.c:46)
    by 0x........: test (mempool2.c:122)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
 
 
 ------ read free in mmap-backed pool ------
 
 Illegal memory pool address
    at 0x........: test (mempool2.c:150)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is not stack'd, malloc'd or (recently) free'd
 
 
@@ -61,19 +61,19 @@ Illegal memory pool address
 
 Illegal memory pool address
    at 0x........: test (mempool2.c:155)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is 0 bytes inside a block of size 32 alloc'd
    at 0x........: malloc (vg_replace_malloc.c:...)
    by 0x........: make_pool (mempool2.c:46)
    by 0x........: test (mempool2.c:122)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
 
 
 ------ double free in mmap-backed pool ------
 
 Illegal memory pool address
    at 0x........: test (mempool2.c:159)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is not stack'd, malloc'd or (recently) free'd
 
 
@@ -81,17 +81,27 @@ Illegal memory pool address
 
 Invalid read of size 1
    at 0x........: test (mempool2.c:178)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is 1 bytes before a block of size 10 client-defined
    at 0x........: test (mempool2.c:171)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
 
 Invalid read of size 1
    at 0x........: test (mempool2.c:179)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
  Address 0x........ is 0 bytes after a block of size 10 client-defined
    at 0x........: test (mempool2.c:171)
-   by 0x........: main (mempool2.c:196)
+   by 0x........: main (mempool2.c:208)
+
+
+------ write to noaccess space close to reallocated object ------
+
+Invalid write of size 1
+   at 0x........: test (mempool2.c:195)
+   by 0x........: main (mempool2.c:208)
+ Address 0x........ is 1 bytes before a block of size 16 free'd
+   at 0x........: test (mempool2.c:190)
+   by 0x........: main (mempool2.c:208)
 
 
 ------ done ------


### PR DESCRIPTION
The error looks like this:

"Memcheck: mc_malloc_wrappers.c:244 (in_block_list): Assertion 'found_mc == mc' failed.

host stacktrace:
 at 0x38083468: show_sched_status_wrk (m_libcassert.c:343)
 by 0x38083584: report_and_quit (m_libcassert.c:415)
 by 0x38083711: vgPlain_assert_fail (m_libcassert.c:481)
 by 0x380504D3: in_block_list (mc_malloc_wrappers.c:244)
 by 0x3805052C: live_block (mc_malloc_wrappers.c:257)
 by 0x38050674: vgMemCheck_allocated_at (mc_malloc_wrappers.c:273)
 by 0x38079DDE: describe_addr (mc_errors.c:1072)
 by 0x3807B393: vgMemCheck_update_Error_extra (mc_errors.c:1141)
 by 0x3807F55A: vgPlain_maybe_record_error (m_errormgr.c:813)
 by 0x3807A95A: vgMemCheck_record_address_error (mc_errors.c:760)"

Note: commit message follows upstream conventions.
