### PR TITLE
pmemcheck: add region coalescing

### DIFF
--- a/pmemcheck/pmc_common.c
+++ b/pmemcheck/pmc_common.c
@@ -53,7 +53,7 @@ is_in_mapping_set(const struct pmem_st *region, OSet *region_set)
 /**
 * \brief Adds a region to a set.
 *
-* Overlapping regions will be merged.
+* Overlapping and neighboring regions will be merged.
 * \param[in] region The region to register.
 * \param[in, out] region_set The region set to which region will be registered.
 */
@@ -66,7 +66,10 @@ add_region(const struct pmem_st *region, OSet *region_set)
     entry->state = STST_CLEAN;
 
     struct pmem_st *old_entry;
-    while ((old_entry = VG_(OSetGen_Remove)(region_set, entry)) != NULL) {
+    struct pmem_st search_entry = *entry;
+    search_entry.addr -= 1;
+    search_entry.size += 2;
+    while ((old_entry = VG_(OSetGen_Remove)(region_set, &search_entry)) != NULL) {
         /* registering overlapping memory regions, glue them together */
         ULong max_addr = MAX(entry->addr + entry->size, old_entry->addr +
                 old_entry->size);

--- a/pmemcheck/pmc_tx.c
+++ b/pmemcheck/pmc_tx.c
@@ -131,7 +131,6 @@ print_thread_transactions(void)
         return;
 
     VG_(dmsg)("Printing thread transactions\n");
-    /* remove the transaction from each thread */
     struct thread_info *elem;
     VG_(OSetGen_ResetIter)(trans.threads);
     while ((elem = VG_(OSetGen_Next)(trans.threads)) != NULL) {

--- a/pmemcheck/tests/address_specific/Makefile.am
+++ b/pmemcheck/tests/address_specific/Makefile.am
@@ -22,10 +22,12 @@ EXTRA_DIST = \
 	region_manipulation.stderr.exp region_manipulation.vgtest \
 	remove_regions.stderr.exp remove_regions.vgtest \
 	remove_aligned_region.stderr.exp remove_aligned_region.vgtest \
-	flush_align.stderr.exp flush_align.vgtest
+	flush_align.stderr.exp flush_align.vgtest \
+	region_coalescing.stderr.exp region_coalescing.vgtest
 
 check_PROGRAMS = \
 	region_manipulation \
 	remove_regions \
 	remove_aligned_region \
-	flush_align
+	flush_align \
+	region_coalescing

--- a/pmemcheck/tests/address_specific/region_coalescing.c
+++ b/pmemcheck/tests/address_specific/region_coalescing.c
@@ -1,0 +1,35 @@
+/*
+ * Persistent memory checker.
+ * Copyright (c) 2014-2015, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, or (at your option) any later version, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#include "../../pmemcheck.h"
+
+
+int main ( void )
+{
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x100, 0x10);
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x110, 0x10);
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x120, 0x10);
+    VALGRIND_PMC_PRINT_PMEM_MAPPINGS;
+
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x200, 0x1);
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x202, 0x1);
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x201, 0x1);
+    VALGRIND_PMC_PRINT_PMEM_MAPPINGS;
+
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x300, 0x1);
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x305, 0x1);
+    VALGRIND_PMC_REGISTER_PMEM_MAPPING(0x303, 0x1);
+    VALGRIND_PMC_PRINT_PMEM_MAPPINGS;
+    return 0;
+}

--- a/pmemcheck/tests/address_specific/region_coalescing.stderr.exp
+++ b/pmemcheck/tests/address_specific/region_coalescing.stderr.exp
@@ -1,0 +1,8 @@
+[0] Mapping base: 0x100	size: 48
+[0] Mapping base: 0x100	size: 48
+[1] Mapping base: 0x200	size: 3
+[0] Mapping base: 0x100	size: 48
+[1] Mapping base: 0x200	size: 3
+[2] Mapping base: 0x300	size: 1
+[3] Mapping base: 0x303	size: 1
+[4] Mapping base: 0x305	size: 1

--- a/pmemcheck/tests/address_specific/region_coalescing.vgtest
+++ b/pmemcheck/tests/address_specific/region_coalescing.vgtest
@@ -1,0 +1,2 @@
+prog: region_coalescing
+vgopts: -q --print-summary=no


### PR DESCRIPTION
Adding adjacent regions causes them to coalesce.
