### PR TITLE
common: switch to docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
-before_install:
-  - sudo apt-get update -qq
+sudo: false
 compiler:
   - gcc
   - clang
-script: ./autogen.sh && ./configure && make && make check
+script: ./autogen.sh && ./configure && make && make check &&
+        perl tests/vg_regtest pmemcheck

--- a/pmemcheck/tests/filter_stderr
+++ b/pmemcheck/tests/filter_stderr
@@ -20,7 +20,9 @@ $dir/../../tests/filter_stderr_basic |
 $dir/../../tests/filter_addresses |
 
 # SSE check filtering.
-sed "s/(emmintrin.h:[0-9]*)/(emmintrin.h:...)/" |
+sed "s/(emmintrin.h:[0-9]*)/(...:...)/" |
+sed "s/(nt_stores.c:[0-9]*)/(...:...)/" |
+sed "s/(sse_stores.c:[0-9]*)/(...:...)/" |
 
 # transaction id check filtering.
 sed "s/tx_id: [1-9]*/tx_id: .../" |

--- a/pmemcheck/tests/nt_stores.stderr.exp
+++ b/pmemcheck/tests/nt_stores.stderr.exp
@@ -1,9 +1,9 @@
 Number of stores not made persistent: 3
 Stores not made persistent properly:
-[0]    at 0x........: main (emmintrin.h:...)
+[0]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[1]    at 0x........: main (emmintrin.h:...)
+[1]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[2]    at 0x........: main (emmintrin.h:...)
+[2]    at 0x........: main (...:...)
 	Address: 0x........	size: 4	state: DIRTY
 Total memory not made persistent: 20

--- a/pmemcheck/tests/sse_stores.stderr.exp
+++ b/pmemcheck/tests/sse_stores.stderr.exp
@@ -1,23 +1,23 @@
 Number of stores not made persistent: 10
 Stores not made persistent properly:
-[0]    at 0x........: main (emmintrin.h:...)
+[0]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[1]    at 0x........: main (emmintrin.h:...)
+[1]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[2]    at 0x........: main (emmintrin.h:...)
+[2]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[3]    at 0x........: main (emmintrin.h:...)
+[3]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[4]    at 0x........: main (emmintrin.h:...)
+[4]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[5]    at 0x........: main (emmintrin.h:...)
+[5]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[6]    at 0x........: main (emmintrin.h:...)
+[6]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[7]    at 0x........: main (emmintrin.h:...)
+[7]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[8]    at 0x........: main (emmintrin.h:...)
+[8]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
-[9]    at 0x........: main (emmintrin.h:...)
+[9]    at 0x........: main (...:...)
 	Address: 0x........	size: 8	state: DIRTY
 Total memory not made persistent: 80


### PR DESCRIPTION
Add pmemcheck tests to travis build process. Because of differences in gcc and
clang, two tests using intrinsics had to be changed.
