### PR TITLE
pmemcheck: flush empty cache fix

### DIFF
--- a/pmemcheck/pmc_common.c
+++ b/pmemcheck/pmc_common.c
@@ -58,7 +58,7 @@ check_overlap(const struct pmem_st *lhs, const struct pmem_st *rhs)
         /* partial overlap */
         return 2;
     else
-        /* region fully within the mapping */
+        /* lhs fully within rhs */
         return 1;
 }
 

--- a/pmemcheck/tests/trans_cache_flush.c
+++ b/pmemcheck/tests/trans_cache_flush.c
@@ -29,6 +29,10 @@ int main ( void )
 
     /* first three should be merged, fourth cached */
     VALGRIND_PMC_ADD_TO_TX_N(1234, i16p, sizeof (*i16p));
+
+    /* check for flush of empty cache */
+    *i16p = 9;
+
     ++i16p;
     VALGRIND_PMC_ADD_TO_TX_N(1234, i16p, sizeof (*i16p));
     ++i16p;


### PR DESCRIPTION
In some weird cases, where the cache was empty, the flush could brake the
whole program.
