### PR TITLE
pmemcheck: fix output of overlapping regions check

### DIFF
--- a/pmemcheck/pmc_tx.c
+++ b/pmemcheck/pmc_tx.c
@@ -203,7 +203,7 @@ print_cross_evs(void)
             VG_(pp_ExeContext)(tmp->duplicate.context);
             VG_(umsg)("\tAddress: 0x%lx\tsize: %llu\ttx_id: %lu\n",
                     tmp->duplicate.addr, tmp->duplicate.size, tmp->dup_tx_id);
-            VG_(umsg)("   First registered here:\n[0]'");
+            VG_(umsg)("   First registered here:\n[%d]'", i);
             VG_(pp_ExeContext)(tmp->original.context);
             VG_(umsg)("\tAddress: 0x%lx\tsize: %llu\ttx_id: %lu\n",
                     tmp->original.addr, tmp->original.size, tmp->orig_tx_id);


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/valgrind/32)

<!-- Reviewable:end -->
