### PR TITLE
memcheck/tests: Use ucontext_t instead of struct ucontext

### DIFF
--- a/memcheck/tests/linux/stack_changes.c
+++ b/memcheck/tests/linux/stack_changes.c
@@ -10,7 +10,7 @@
 // This test is checking the libc context calls (setcontext, etc.) and
 // checks that Valgrind notices their stack changes properly.
 
-typedef  struct ucontext  mycontext;
+typedef  ucontext_t  mycontext;
 
 mycontext ctx1, ctx2, oldc;
 int count;


### PR DESCRIPTION
Intention of this PR is to provide solution for broken configuration.

After calling make check.

stack_changes.c: At top level:
stack_changes.c:15:11: error: storage size of ‘ctx1’ isn’t known
 mycontext ctx1, ctx2, oldc;
           ^~~~
stack_changes.c:15:17: error: storage size of ‘ctx2’ isn’t known
 mycontext ctx1, ctx2, oldc;
                 ^~~~
stack_changes.c:15:23: error: storage size of ‘oldc’ isn’t known
 mycontext ctx1, ctx2, oldc;
                       ^~~~
Makefile:762: recipe for target 'stack_changes.o' failed
make[5]: *** [stack_changes.o] Error 1

OS Environment: 
Ubuntu 18.04 LTS
gcc (Ubuntu 8.1.0-1ubuntu1) 8.1.0
Ubuntu GLIBC 2.27-3ubuntu1

For details please see:
https://sourceware.org/glibc/wiki/Release/2.26 section 4.2


-------
Original commit in valgrind repository:
2b5eab6a8db1b0487a3ad7fc4e7eeda6d3513626

glibc 2.26 does not expose struct ucontext anymore.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

git-svn-id: svn://svn.valgrind.org/valgrind/trunk@16457

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/valgrind/55)
<!-- Reviewable:end -->
