### PR TITLE
Handle 64-bit float stores

### DIFF
--- a/pmemcheck/pmc_main.c
+++ b/pmemcheck/pmc_main.c
@@ -966,6 +966,16 @@ add_event_dw_guarded(IRSB *sb, IRAtom *daddr, Int dsize, IRAtom *guard,
             di->guard = guard;
         }
         addStmtToIRSB(sb, IRStmt_Dirty(di));
+    } else if (value->tag == Iex_RdTmp && type == Ity_F64) {
+        argv = mkIRExprVec_3(daddr, mkIRExpr_HWord(dsize),
+                make_expr(sb, Ity_I64, unop(Iop_ReinterpF64asI64,
+                        value)));
+        di = unsafeIRDirty_0_N(/*regparms*/3, helperName,
+                VG_(fnptr_to_fnentry)(helperAddr), argv);
+        if (guard) {
+            di->guard = guard;
+        }
+        addStmtToIRSB(sb, IRStmt_Dirty(di));
     } else if (value->tag == Iex_RdTmp && tmp_needs_widen(type)) {
         /* the operation needs to be widened */
         argv = mkIRExprVec_3(daddr, mkIRExpr_HWord(dsize),

--- a/pmemcheck/pmc_main.c
+++ b/pmemcheck/pmc_main.c
@@ -990,7 +990,8 @@ add_event_dw_guarded(IRSB *sb, IRAtom *daddr, Int dsize, IRAtom *guard,
     } else if (type == Ity_V128 || type == Ity_V256 ) {
         handle_wide_expr(sb, Iend_LE, daddr, value, guard, dsize);
     } else {
-        VG_(umsg)("Unable to trace store - unsupported type of store\n");
+        VG_(umsg)("Unable to trace store - unsupported type of store 0x%x 0x%x\n",
+                  value->tag, type);
     }
 }
 

--- a/pmemcheck/tests/Makefile.am
+++ b/pmemcheck/tests/Makefile.am
@@ -21,6 +21,9 @@ dist_noinst_SCRIPTS = \
 
 noinst_HEADERS = common.h
 
+# to trigger 64-bit float store
+floats_CFLAGS = -mno-sse2 -g -O3
+
 EXTRA_DIST = \
 	const_store.stderr.exp const_store.vgtest \
 	tmp_store.stderr.exp tmp_store.vgtest \
@@ -45,7 +48,8 @@ EXTRA_DIST = \
 	trans_cache_overl.stderr.exp trans_cache_overl.vgtest \
 	trans_cache_flush.stderr.exp trans_cache_flush.vgtest \
 	store_merge.stderr.exp store_merge.vgtest \
-	store_split.stderr.exp store_split.vgtest
+	store_split.stderr.exp store_split.vgtest \
+	floats.stderr.exp floats.vgtest
 
 check_PROGRAMS = \
 	const_store \
@@ -71,4 +75,5 @@ check_PROGRAMS = \
 	trans_cache_overl \
 	trans_cache_flush \
 	store_merge \
-	store_split
+	store_split \
+	floats

--- a/pmemcheck/tests/floats.c
+++ b/pmemcheck/tests/floats.c
@@ -1,0 +1,33 @@
+/*
+ * Persistent memory checker.
+ * Copyright (c) 2014-2018, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, or (at your option) any later version, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#include "common.h"
+#include <stdint.h>
+#include <stdio.h>
+
+#define FILE_SIZE (16 * 1024 * 1024)
+
+int main ( void )
+{
+    /* make, map and register a temporary file */
+    void *base = make_map_tmpfile(FILE_SIZE);
+
+    float *floatp = (float *)((uintptr_t)base);
+    double *doublep = (double *)((uintptr_t)base + 16);
+
+    *floatp = 1.0;
+    *doublep = 2.0;
+
+    return 0;
+}

--- a/pmemcheck/tests/floats.stderr.exp
+++ b/pmemcheck/tests/floats.stderr.exp
@@ -1,0 +1,9 @@
+START|STORE;0x........;0x........;0x........|STORE;0x........;0x........;0x........|STOP
+Number of stores not made persistent: 2
+Stores not made persistent properly:
+[0]    at 0x........: main (floats.c:29)
+	Address: 0x........	size: 4	state: DIRTY
+[1]    at 0x........: main (floats.c:30)
+	Address: 0x........	size: 8	state: DIRTY
+Total memory not made persistent: 12
+ERROR SUMMARY: 2 errors

--- a/pmemcheck/tests/floats.vgtest
+++ b/pmemcheck/tests/floats.vgtest
@@ -1,0 +1,2 @@
+prog: floats
+vgopts: --log-stores=yes --isa-rec=no -q


### PR DESCRIPTION
Fixes errors like this:
"Unable to trace store - unsupported type of store"

Triggered by Java runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/valgrind/63)
<!-- Reviewable:end -->
