### PR TITLE
coregrind: Bug 396887 - arch_prctl should return EINVAL on unknown option

### DIFF
--- a/coregrind/m_syswrap/syswrap-amd64-linux.c
+++ b/coregrind/m_syswrap/syswrap-amd64-linux.c
@@ -249,6 +249,7 @@ PRE(sys_rt_sigreturn)
 PRE(sys_arch_prctl)
 {
    ThreadState* tst;
+   Bool known_option = True;
    PRINT( "arch_prctl ( %ld, %lx )", SARG1, ARG2 );
 
    vg_assert(VG_(is_valid_tid)(tid));
@@ -283,13 +284,16 @@ PRE(sys_arch_prctl)
       POST_MEM_WRITE(ARG2, sizeof(unsigned long));
    }
    else {
-      VG_(core_panic)("Unsupported arch_prctl option");
+      known_option = False;
    }
 
    /* Note; the Status writeback to guest state that happens after
       this wrapper returns does not change guest_FS_CONST or guest_GS_CONST;
       hence that direct assignment to the guest state is safe here. */
-   SET_STATUS_Success( 0 );
+   if (known_option)
+      SET_STATUS_Success( 0 );
+   else
+      SET_STATUS_Failure( VKI_EINVAL );
 }
 
 // Parts of this are amd64-specific, but the *PEEK* cases are generic.


### PR DESCRIPTION
This is a backport of the valgrind v3.14 upstream patch:

commit 21a01b13e259b9a43f10f0046b2b3f409c11ea75
Author: Mark Wielaard <mark@klomp.org>
Date:   Mon Jul 30 12:20:16 2018 +0200
Bug 396887 - arch_prctl should return EINVAL on unknown option.

that fixes a bug which occurs with glibc>=2.28.

---

Currently arch_prctl calls VG_(core_panic) when it sees an unknown
arch_prctl option which kills the process. glibc uses arch_prctl with
an (as yet) unknown option to see if the kernel supports CET. This
breaks any application running under valgrind on x86_64 with:

valgrind: the 'impossible' happened:
   Unsupported arch_prctl option

Thread 1: status = VgTs_Runnable (lwpid 19934)
==19934==    at 0x121A15: get_cet_status (cpu-features.c:28)
==19934==    by 0x121A15: init_cpu_features (cpu-features.c:474)
==19934==    by 0x121A15: dl_platform_init (dl-machine.h:228)
==19934==    by 0x121A15: _dl_sysdep_start (dl-sysdep.c:231)
==19934==    by 0x10A1D7: _dl_start_final (rtld.c:413)
==19934==    by 0x10A1D7: _dl_start (rtld.c:520)

We already handle all known options. It would be better to do as the
kernel does and just return failure with EINVAL instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/valgrind/64)
<!-- Reviewable:end -->
