### PR TITLE
fix memcheck failure on Ubuntu-19.04

### DIFF
--- a/coregrind/m_debuginfo/readelf.c
+++ b/coregrind/m_debuginfo/readelf.c
@@ -1318,6 +1318,7 @@ DiImage* find_debug_file( struct _DebugInfo* di,
 
    if (dimg == NULL && debugname != NULL) {
       HChar *objdir = ML_(dinfo_strdup)("di.fdf.2", objpath);
+      HChar *usrmerge_objdir = objdir;
       HChar *objdirptr;
 
       if ((objdirptr = VG_(strrchr)(objdir, '/')) != NULL)
@@ -1335,7 +1336,14 @@ DiImage* find_debug_file( struct _DebugInfo* di,
          if (dimg != NULL) goto dimg_ok;
       }
 
+      if ((objdirptr = VG_(strstr)(usrmerge_objdir, "usr")) != NULL)
+         usrmerge_objdir = objdirptr + VG_(strlen)("usr");
+
       VG_(sprintf)(debugpath, "%s/%s", objdir, debugname);
+      dimg = open_debug_file(debugpath, buildid, crc, rel_ok, NULL);
+      if (dimg != NULL) goto dimg_ok;
+
+      VG_(sprintf)(debugpath, "%s/%s", usrmerge_objdir, debugname);
       dimg = open_debug_file(debugpath, buildid, crc, rel_ok, NULL);
       if (dimg != NULL) goto dimg_ok;
 
@@ -1343,13 +1351,26 @@ DiImage* find_debug_file( struct _DebugInfo* di,
       dimg = open_debug_file(debugpath, buildid, crc, rel_ok, NULL);
       if (dimg != NULL) goto dimg_ok;
       
+      VG_(sprintf)(debugpath, "%s/.debug/%s", usrmerge_objdir, debugname);
+      dimg = open_debug_file(debugpath, buildid, crc, rel_ok, NULL);
+      if (dimg != NULL) goto dimg_ok;
+
       VG_(sprintf)(debugpath, "/usr/lib/debug%s/%s", objdir, debugname);
+      dimg = open_debug_file(debugpath, buildid, crc, rel_ok, NULL);
+      if (dimg != NULL) goto dimg_ok;
+
+      VG_(sprintf)(debugpath, "/usr/lib/debug%s/%s", usrmerge_objdir, debugname);
       dimg = open_debug_file(debugpath, buildid, crc, rel_ok, NULL);
       if (dimg != NULL) goto dimg_ok;
 
       if (extrapath) {
          VG_(sprintf)(debugpath, "%s%s/%s", extrapath,
                                             objdir, debugname);
+         dimg = open_debug_file(debugpath, buildid, crc, rel_ok, NULL);
+         if (dimg != NULL) goto dimg_ok;
+
+         VG_(sprintf)(debugpath, "%s%s/%s", extrapath,
+                                            usrmerge_objdir, debugname);
          dimg = open_debug_file(debugpath, buildid, crc, rel_ok, NULL);
          if (dimg != NULL) goto dimg_ok;
       }


### PR DESCRIPTION
Tests under memcheck fail on Ubuntu-19.04 although package libc6-dbg is installed:

-- Stderr:
==2521== Memcheck, a memory error detector
==2521== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2521== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==2521== 

valgrind:  Fatal error at startup: a function redirection
valgrind:  which is mandatory for this platform-tool combination
valgrind:  cannot be set up.  Details of the redirection are:
valgrind:  
valgrind:  A must-be-redirected function
valgrind:  whose name matches the pattern:      strlen
valgrind:  in an object with soname matching:   ld-linux-x86-64.so.2
valgrind:  was not found whilst processing
valgrind:  symbols from the object with soname: ld-linux-x86-64.so.2
valgrind:  
valgrind:  Possible fixes: (1, short term): install glibc's debuginfo
valgrind:  package on this machine.  (2, longer term): ask the packagers
valgrind:  for your Linux distribution to please in future ship a non-
valgrind:  stripped ld.so (or whatever the dynamic linker .so is called)
valgrind:  that exports the above-named function using the standard
valgrind:  calling conventions for this platform.  The package you need
valgrind:  to install for fix (1) is called
valgrind:  
valgrind:    On Debian, Ubuntu:                 libc6-dbg
valgrind:    On SuSE, openSuSE, Fedora, RHEL:   glibc-debuginfo
valgrind:  
valgrind:  Note that if you are debugging a 32 bit process on a
valgrind:  64 bit system, you will need a corresponding 32 bit debuginfo
valgrind:  package (e.g. libc6-dbg:i386).
valgrind:  
valgrind:  Cannot continue -- exiting now.  Sorry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/valgrind/73)
<!-- Reviewable:end -->
