### PR TITLE
Fix typo in manual

### DIFF
--- a/pmemcheck/docs/pmc-manual.xml
+++ b/pmemcheck/docs/pmc-manual.xml
@@ -550,7 +550,7 @@ Overlapping regions:
 
 	  <varlistentry id="crm.flush" xreflabel="VALGRIND_PMC_DO_FLUSH">
 	    <term>
-		  <option><![CDATA[VALGRIND_PMC_DO_CLFLUSH(addr, size)]]></option>
+		  <option><![CDATA[VALGRIND_PMC_DO_FLUSH(addr, size)]]></option>
         </term>
 		<listitem>
 		  <para>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/valgrind/87)
<!-- Reviewable:end -->
